### PR TITLE
Add i18n support and generate POT file

### DIFF
--- a/acme-biaquiz.php
+++ b/acme-biaquiz.php
@@ -39,22 +39,23 @@ class ACME_BIAQuiz {
     public function init() {
         $this->create_post_types();
         $this->create_taxonomies();
+        load_plugin_textdomain('acme-biaquiz', false, dirname(plugin_basename(__FILE__)) . '/languages');
     }
     
     public function create_post_types() {
         // Quiz Post Type
         register_post_type('biaquiz', array(
             'labels' => array(
-                'name' => 'Quiz BIA',
-                'singular_name' => 'Quiz',
-                'add_new' => 'Ajouter un Quiz',
-                'add_new_item' => 'Ajouter un nouveau Quiz',
-                'edit_item' => 'Modifier le Quiz',
-                'new_item' => 'Nouveau Quiz',
-                'view_item' => 'Voir le Quiz',
-                'search_items' => 'Rechercher des Quiz',
-                'not_found' => 'Aucun quiz trouvé',
-                'not_found_in_trash' => 'Aucun quiz dans la corbeille'
+                'name' => __('Quiz BIA', 'acme-biaquiz'),
+                'singular_name' => __('Quiz', 'acme-biaquiz'),
+                'add_new' => __('Ajouter un Quiz', 'acme-biaquiz'),
+                'add_new_item' => __('Ajouter un nouveau Quiz', 'acme-biaquiz'),
+                'edit_item' => __('Modifier le Quiz', 'acme-biaquiz'),
+                'new_item' => __('Nouveau Quiz', 'acme-biaquiz'),
+                'view_item' => __('Voir le Quiz', 'acme-biaquiz'),
+                'search_items' => __('Rechercher des Quiz', 'acme-biaquiz'),
+                'not_found' => __('Aucun quiz trouvé', 'acme-biaquiz'),
+                'not_found_in_trash' => __('Aucun quiz dans la corbeille', 'acme-biaquiz')
             ),
             'public' => false,
             'show_ui' => true,
@@ -70,12 +71,12 @@ class ACME_BIAQuiz {
         // Quiz Categories
         register_taxonomy('biaquiz_category', 'biaquiz', array(
             'labels' => array(
-                'name' => 'Catégories BIA',
-                'singular_name' => 'Catégorie',
-                'add_new_item' => 'Ajouter une catégorie',
-                'edit_item' => 'Modifier la catégorie',
-                'update_item' => 'Mettre à jour la catégorie',
-                'search_items' => 'Rechercher des catégories'
+                'name' => __('Catégories BIA', 'acme-biaquiz'),
+                'singular_name' => __('Catégorie', 'acme-biaquiz'),
+                'add_new_item' => __('Ajouter une catégorie', 'acme-biaquiz'),
+                'edit_item' => __('Modifier la catégorie', 'acme-biaquiz'),
+                'update_item' => __('Mettre à jour la catégorie', 'acme-biaquiz'),
+                'search_items' => __('Rechercher des catégories', 'acme-biaquiz')
             ),
             'hierarchical' => true,
             'public' => false,
@@ -109,8 +110,8 @@ class ACME_BIAQuiz {
     
     public function admin_menu() {
         add_menu_page(
-            'ACME BIAQuiz',
-            'BIAQuiz',
+            __('ACME BIAQuiz', 'acme-biaquiz'),
+            __('BIAQuiz', 'acme-biaquiz'),
             'manage_options',
             'biaquiz-dashboard',
             array($this, 'admin_dashboard'),
@@ -120,24 +121,24 @@ class ACME_BIAQuiz {
         
         add_submenu_page(
             'biaquiz-dashboard',
-            'Tous les Quiz',
-            'Tous les Quiz',
+            __('Tous les Quiz', 'acme-biaquiz'),
+            __('Tous les Quiz', 'acme-biaquiz'),
             'manage_options',
             'edit.php?post_type=biaquiz'
         );
         
         add_submenu_page(
             'biaquiz-dashboard',
-            'Catégories',
-            'Catégories',
+            __('Catégories', 'acme-biaquiz'),
+            __('Catégories', 'acme-biaquiz'),
             'manage_options',
             'edit-tags.php?taxonomy=biaquiz_category&post_type=biaquiz'
         );
         
         add_submenu_page(
             'biaquiz-dashboard',
-            'Import/Export',
-            'Import/Export',
+            __('Import/Export', 'acme-biaquiz'),
+            __('Import/Export', 'acme-biaquiz'),
             'manage_options',
             'biaquiz-import-export',
             array($this, 'admin_import_export')
@@ -156,7 +157,7 @@ class ACME_BIAQuiz {
         check_ajax_referer('biaquiz_admin_nonce', 'nonce');
         
         if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
+            wp_die(__('Unauthorized', 'acme-biaquiz'));
         }
         
         $category = sanitize_text_field($_POST['category']);
@@ -177,7 +178,7 @@ class ACME_BIAQuiz {
         $header = str_getcsv(array_shift($lines));
         
         if (!$this->validate_csv_header($header)) {
-            return array('success' => false, 'message' => 'Format CSV invalide');
+            return array('success' => false, 'message' => __('Format CSV invalide', 'acme-biaquiz'));
         }
         
         $questions = array();
@@ -196,7 +197,7 @@ class ACME_BIAQuiz {
         }
         
         if (count($questions) !== 20) {
-            return array('success' => false, 'message' => 'Un quiz doit contenir exactement 20 questions');
+            return array('success' => false, 'message' => __('Un quiz doit contenir exactement 20 questions', 'acme-biaquiz'));
         }
         
         return $this->create_quiz($category, $questions);
@@ -206,7 +207,7 @@ class ACME_BIAQuiz {
         $data = json_decode($json_data, true);
         
         if (!$data || !isset($data['questions']) || count($data['questions']) !== 20) {
-            return array('success' => false, 'message' => 'Format JSON invalide ou nombre de questions incorrect');
+            return array('success' => false, 'message' => __('Format JSON invalide ou nombre de questions incorrect', 'acme-biaquiz'));
         }
         
         return $this->create_quiz($category, $data['questions']);
@@ -224,7 +225,7 @@ class ACME_BIAQuiz {
         // Get category term
         $term = get_term_by('slug', $category, 'biaquiz_category');
         if (!$term) {
-            return array('success' => false, 'message' => 'Catégorie introuvable');
+            return array('success' => false, 'message' => __('Catégorie introuvable', 'acme-biaquiz'));
         }
         
         // Create quiz post
@@ -240,10 +241,10 @@ class ACME_BIAQuiz {
         
         if ($post_id) {
             wp_set_object_terms($post_id, $category, 'biaquiz_category');
-            return array('success' => true, 'message' => 'Quiz importé avec succès');
+            return array('success' => true, 'message' => __('Quiz importé avec succès', 'acme-biaquiz'));
         }
         
-        return array('success' => false, 'message' => 'Erreur lors de la création du quiz');
+        return array('success' => false, 'message' => __('Erreur lors de la création du quiz', 'acme-biaquiz'));
     }
     
     private function get_next_quiz_number($category) {
@@ -276,7 +277,7 @@ class ACME_BIAQuiz {
         check_ajax_referer('biaquiz_admin_nonce', 'nonce');
         
         if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized');
+            wp_die(__('Unauthorized', 'acme-biaquiz'));
         }
         
         $category = sanitize_text_field($_POST['category']);
@@ -322,7 +323,7 @@ class ACME_BIAQuiz {
         $quiz = get_post($quiz_id);
         
         if (!$quiz || $quiz->post_type !== 'biaquiz') {
-            wp_send_json_error('Quiz introuvable');
+            wp_send_json_error(__('Quiz introuvable', 'acme-biaquiz'));
         }
         
         $questions = json_decode(get_post_meta($quiz_id, 'biaquiz_questions', true), true);
@@ -351,12 +352,36 @@ class ACME_BIAQuiz {
         
         // Create default categories
         $categories = array(
-            array('slug' => 'aerodynamics', 'name' => 'Aérodynamique et mécanique du vol', 'description' => 'Principes de vol, portance, traînée, facteurs de charge'),
-            array('slug' => 'aircraft', 'name' => 'Connaissance des aéronefs', 'description' => 'Structure, systèmes, motorisation, équipements'),
-            array('slug' => 'meteorology', 'name' => 'Météorologie', 'description' => 'Masses d\'air, nuages, phénomènes météorologiques'),
-            array('slug' => 'navigation', 'name' => 'Navigation, règlementation et sécurité', 'description' => 'Navigation, réglementation aérienne, sécurité des vols'),
-            array('slug' => 'history', 'name' => 'Histoire de l\'aéronautique et de l\'espace', 'description' => 'Pionniers, évolution technologique, conquête spatiale'),
-            array('slug' => 'english', 'name' => 'Anglais aéronautique', 'description' => 'Vocabulaire technique, phraséologie radio')
+            array(
+                'slug'        => 'aerodynamics',
+                'name'        => __('Aérodynamique et mécanique du vol', 'acme-biaquiz'),
+                'description' => __('Principes de vol, portance, traînée, facteurs de charge', 'acme-biaquiz'),
+            ),
+            array(
+                'slug'        => 'aircraft',
+                'name'        => __('Connaissance des aéronefs', 'acme-biaquiz'),
+                'description' => __('Structure, systèmes, motorisation, équipements', 'acme-biaquiz'),
+            ),
+            array(
+                'slug'        => 'meteorology',
+                'name'        => __('Météorologie', 'acme-biaquiz'),
+                'description' => __('Masses d\'air, nuages, phénomènes météorologiques', 'acme-biaquiz'),
+            ),
+            array(
+                'slug'        => 'navigation',
+                'name'        => __('Navigation, règlementation et sécurité', 'acme-biaquiz'),
+                'description' => __('Navigation, réglementation aérienne, sécurité des vols', 'acme-biaquiz'),
+            ),
+            array(
+                'slug'        => 'history',
+                'name'        => __('Histoire de l\'aéronautique et de l\'espace', 'acme-biaquiz'),
+                'description' => __('Pionniers, évolution technologique, conquête spatiale', 'acme-biaquiz'),
+            ),
+            array(
+                'slug'        => 'english',
+                'name'        => __('Anglais aéronautique', 'acme-biaquiz'),
+                'description' => __('Vocabulaire technique, phraséologie radio', 'acme-biaquiz'),
+            ),
         );
         
         foreach ($categories as $category) {

--- a/languages/acme-biaquiz.pot
+++ b/languages/acme-biaquiz.pot
@@ -1,0 +1,437 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-27 08:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: templates/quiz-frontend.php:10
+msgid "Chargement..."
+msgstr ""
+
+#: templates/quiz-frontend.php:19 acme-biaquiz.php:113
+msgid "ACME BIAQuiz"
+msgstr ""
+
+#: templates/quiz-frontend.php:20
+msgid "Entraînement au Brevet d'Initiation à l'Aéronautique"
+msgstr ""
+
+#: templates/quiz-frontend.php:26
+msgid "Préparez votre BIA efficacement"
+msgstr ""
+
+#: templates/quiz-frontend.php:27
+msgid ""
+"Entrainez-vous avec nos quiz thématiques interactifs. Aucune inscription "
+"requise, correction immédiate et répétition des erreurs jusqu'à la maîtrise "
+"parfaite."
+msgstr ""
+
+#: templates/quiz-frontend.php:33
+msgid "Catégories disponibles"
+msgstr ""
+
+#: templates/quiz-frontend.php:37
+msgid "Questions d'entraînement"
+msgstr ""
+
+#: templates/quiz-frontend.php:41
+msgid "Score requis pour valider"
+msgstr ""
+
+#: templates/quiz-frontend.php:46
+msgid "Choisissez votre domaine d'entraînement"
+msgstr ""
+
+#: templates/quiz-frontend.php:76
+msgid "quiz disponible"
+msgstr ""
+
+#: templates/quiz-frontend.php:76
+msgid "s"
+msgstr ""
+
+#: templates/quiz-frontend.php:77
+msgid "Commencer l'entraînement →"
+msgstr ""
+
+#: templates/quiz-frontend.php:85
+msgid "Comment ça marche ?"
+msgstr ""
+
+#: templates/quiz-frontend.php:87
+msgid "Choisissez une catégorie selon vos besoins de révision"
+msgstr ""
+
+#: templates/quiz-frontend.php:88
+msgid "Répondez aux 20 questions du quiz sélectionné"
+msgstr ""
+
+#: templates/quiz-frontend.php:89
+msgid "Reprenez les questions ratées jusqu'à obtenir 20/20"
+msgstr ""
+
+#: templates/quiz-frontend.php:93
+msgid "Avantages"
+msgstr ""
+
+#: templates/quiz-frontend.php:95
+msgid "✅ Accès immédiat sans inscription"
+msgstr ""
+
+#: templates/quiz-frontend.php:96
+msgid "✅ Correction et explication instantanées"
+msgstr ""
+
+#: templates/quiz-frontend.php:97
+msgid "✅ Répétition intelligente des erreurs"
+msgstr ""
+
+#: templates/quiz-frontend.php:98
+msgid "✅ Interface responsive et intuitive"
+msgstr ""
+
+#: templates/quiz-frontend.php:99
+msgid "✅ Contenu officiel conforme au BIA"
+msgstr ""
+
+#: templates/quiz-frontend.php:108
+msgid "Retour aux catégories"
+msgstr ""
+
+#: templates/quiz-frontend.php:125
+msgid "Retour"
+msgstr ""
+
+#: templates/quiz-frontend.php:137
+msgid "Question 1/20"
+msgstr ""
+
+#: templates/quiz-frontend.php:138
+msgid "vers 20/20"
+msgstr ""
+
+#: templates/quiz-frontend.php:143
+msgid "Mode révision : Reprise des questions incorrectes"
+msgstr ""
+
+#: templates/quiz-frontend.php:156
+msgid "Explication"
+msgstr ""
+
+#: templates/quiz-frontend.php:165
+msgid "Valider"
+msgstr ""
+
+#: templates/quiz-frontend.php:166
+msgid "Question suivante"
+msgstr ""
+
+#: templates/quiz-frontend.php:176
+msgid "Félicitations !"
+msgstr ""
+
+#: templates/quiz-frontend.php:177
+msgid "Vous avez terminé le quiz avec un score parfait"
+msgstr ""
+
+#: templates/quiz-frontend.php:181
+msgid "Score parfait !"
+msgstr ""
+
+#: templates/quiz-frontend.php:185
+msgid "Recommencer"
+msgstr ""
+
+#: templates/quiz-frontend.php:186
+msgid "Retour aux quiz"
+msgstr ""
+
+#: templates/admin-dashboard.php:10
+msgid "ACME BIAQuiz - Tableau de bord"
+msgstr ""
+
+#: templates/admin-dashboard.php:16
+msgid "Quiz disponibles"
+msgstr ""
+
+#: templates/admin-dashboard.php:21 acme-biaquiz.php:132 acme-biaquiz.php:133
+msgid "Catégories"
+msgstr ""
+
+#: templates/admin-dashboard.php:26
+msgid "Questions totales"
+msgstr ""
+
+#: templates/admin-dashboard.php:31
+msgid "Aperçu des catégories"
+msgstr ""
+
+#: templates/admin-dashboard.php:60
+msgid "Actions rapides"
+msgstr ""
+
+#: templates/admin-dashboard.php:64 templates/admin-import-export.php:12
+msgid "Importer un quiz"
+msgstr ""
+
+#: templates/admin-dashboard.php:65
+msgid "Téléversez vos quiz au format CSV ou JSON"
+msgstr ""
+
+#: templates/admin-dashboard.php:70
+msgid "Créer un quiz"
+msgstr ""
+
+#: templates/admin-dashboard.php:71
+msgid "Créez un nouveau quiz manuellement"
+msgstr ""
+
+#: templates/admin-dashboard.php:76
+msgid "Gérer les quiz"
+msgstr ""
+
+#: templates/admin-dashboard.php:77
+msgid "Voir et modifier tous les quiz existants"
+msgstr ""
+
+#: templates/admin-dashboard.php:83
+msgid "Utilisation"
+msgstr ""
+
+#: templates/admin-dashboard.php:84
+msgid ""
+"Pour afficher l'interface de quiz sur une page ou un article, utilisez le "
+"shortcode :"
+msgstr ""
+
+#: templates/admin-dashboard.php:87
+msgid "Vous pouvez également afficher une catégorie spécifique :"
+msgstr ""
+
+#: templates/admin-dashboard.php:90
+msgid "Ou un quiz spécifique :"
+msgstr ""
+
+#: templates/admin-import-export.php:8
+msgid "Import / Export des Quiz"
+msgstr ""
+
+#: templates/admin-import-export.php:16 acme-biaquiz.php:75
+msgid "Catégorie"
+msgstr ""
+
+#: templates/admin-import-export.php:19 templates/admin-import-export.php:72
+msgid "Sélectionner une catégorie"
+msgstr ""
+
+#: templates/admin-import-export.php:29
+msgid "Format"
+msgstr ""
+
+#: templates/admin-import-export.php:32
+msgid "CSV"
+msgstr ""
+
+#: templates/admin-import-export.php:35
+msgid "JSON"
+msgstr ""
+
+#: templates/admin-import-export.php:40
+msgid "Données"
+msgstr ""
+
+#: templates/admin-import-export.php:44
+msgid ""
+"Format CSV attendu : question,option1,option2,option3,option4,correct_answer,"
+"explanation"
+msgstr ""
+
+#: templates/admin-import-export.php:45
+msgid "Le quiz doit contenir exactement 20 questions."
+msgstr ""
+
+#: templates/admin-import-export.php:52
+msgid "Importer le quiz"
+msgstr ""
+
+#: templates/admin-import-export.php:57
+msgid "Exemple de format CSV"
+msgstr ""
+
+#: templates/admin-import-export.php:65
+msgid "Exporter des quiz"
+msgstr ""
+
+#: templates/admin-import-export.php:69
+msgid "Catégorie à exporter"
+msgstr ""
+
+#: templates/admin-import-export.php:84
+msgid "Exporter en CSV"
+msgstr ""
+
+#: acme-biaquiz.php:49
+msgid "Quiz BIA"
+msgstr ""
+
+#: acme-biaquiz.php:50
+msgid "Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:51
+msgid "Ajouter un Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:52
+msgid "Ajouter un nouveau Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:53
+msgid "Modifier le Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:54
+msgid "Nouveau Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:55
+msgid "Voir le Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:56
+msgid "Rechercher des Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:57
+msgid "Aucun quiz trouvé"
+msgstr ""
+
+#: acme-biaquiz.php:58
+msgid "Aucun quiz dans la corbeille"
+msgstr ""
+
+#: acme-biaquiz.php:74
+msgid "Catégories BIA"
+msgstr ""
+
+#: acme-biaquiz.php:76
+msgid "Ajouter une catégorie"
+msgstr ""
+
+#: acme-biaquiz.php:77
+msgid "Modifier la catégorie"
+msgstr ""
+
+#: acme-biaquiz.php:78
+msgid "Mettre à jour la catégorie"
+msgstr ""
+
+#: acme-biaquiz.php:79
+msgid "Rechercher des catégories"
+msgstr ""
+
+#: acme-biaquiz.php:114
+msgid "BIAQuiz"
+msgstr ""
+
+#: acme-biaquiz.php:124 acme-biaquiz.php:125
+msgid "Tous les Quiz"
+msgstr ""
+
+#: acme-biaquiz.php:140 acme-biaquiz.php:141
+msgid "Import/Export"
+msgstr ""
+
+#: acme-biaquiz.php:160 acme-biaquiz.php:280
+msgid "Unauthorized"
+msgstr ""
+
+#: acme-biaquiz.php:181
+msgid "Format CSV invalide"
+msgstr ""
+
+#: acme-biaquiz.php:200
+msgid "Un quiz doit contenir exactement 20 questions"
+msgstr ""
+
+#: acme-biaquiz.php:210
+msgid "Format JSON invalide ou nombre de questions incorrect"
+msgstr ""
+
+#: acme-biaquiz.php:228
+msgid "Catégorie introuvable"
+msgstr ""
+
+#: acme-biaquiz.php:244
+msgid "Quiz importé avec succès"
+msgstr ""
+
+#: acme-biaquiz.php:247
+msgid "Erreur lors de la création du quiz"
+msgstr ""
+
+#: acme-biaquiz.php:326
+msgid "Quiz introuvable"
+msgstr ""
+
+#: acme-biaquiz.php:357
+msgid "Aérodynamique et mécanique du vol"
+msgstr ""
+
+#: acme-biaquiz.php:358
+msgid "Principes de vol, portance, traînée, facteurs de charge"
+msgstr ""
+
+#: acme-biaquiz.php:362
+msgid "Connaissance des aéronefs"
+msgstr ""
+
+#: acme-biaquiz.php:363
+msgid "Structure, systèmes, motorisation, équipements"
+msgstr ""
+
+#: acme-biaquiz.php:367
+msgid "Météorologie"
+msgstr ""
+
+#: acme-biaquiz.php:368
+msgid "Masses d'air, nuages, phénomènes météorologiques"
+msgstr ""
+
+#: acme-biaquiz.php:372
+msgid "Navigation, règlementation et sécurité"
+msgstr ""
+
+#: acme-biaquiz.php:373
+msgid "Navigation, réglementation aérienne, sécurité des vols"
+msgstr ""
+
+#: acme-biaquiz.php:377
+msgid "Histoire de l'aéronautique et de l'espace"
+msgstr ""
+
+#: acme-biaquiz.php:378
+msgid "Pionniers, évolution technologique, conquête spatiale"
+msgstr ""
+
+#: acme-biaquiz.php:382
+msgid "Anglais aéronautique"
+msgstr ""
+
+#: acme-biaquiz.php:383
+msgid "Vocabulaire technique, phraséologie radio"
+msgstr ""

--- a/templates/admin-dashboard.php
+++ b/templates/admin-dashboard.php
@@ -7,28 +7,28 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
 ?>
 
 <div class="wrap">
-    <h1>ACME BIAQuiz - Tableau de bord</h1>
+    <h1><?php echo esc_html__('ACME BIAQuiz - Tableau de bord', 'acme-biaquiz'); ?></h1>
     
     <div class="biaquiz-dashboard">
         <div class="biaquiz-stats-grid">
             <div class="biaquiz-stat-card">
                 <div class="biaquiz-stat-number"><?php echo $total_quizzes; ?></div>
-                <div class="biaquiz-stat-label">Quiz disponibles</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Quiz disponibles', 'acme-biaquiz'); ?></div>
             </div>
             
             <div class="biaquiz-stat-card">
                 <div class="biaquiz-stat-number"><?php echo count($categories); ?></div>
-                <div class="biaquiz-stat-label">Catégories</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Catégories', 'acme-biaquiz'); ?></div>
             </div>
             
             <div class="biaquiz-stat-card">
                 <div class="biaquiz-stat-number"><?php echo $total_quizzes * 20; ?></div>
-                <div class="biaquiz-stat-label">Questions totales</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Questions totales', 'acme-biaquiz'); ?></div>
             </div>
         </div>
         
         <div class="biaquiz-categories-overview">
-            <h2>Aperçu des catégories</h2>
+            <h2><?php echo esc_html__('Aperçu des catégories', 'acme-biaquiz'); ?></h2>
             <div class="biaquiz-categories-grid">
                 <?php foreach ($categories as $category): 
                     $quiz_count = wp_count_posts('biaquiz');
@@ -57,37 +57,37 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
         </div>
         
         <div class="biaquiz-quick-actions">
-            <h2>Actions rapides</h2>
+            <h2><?php echo esc_html__('Actions rapides', 'acme-biaquiz'); ?></h2>
             <div class="biaquiz-actions-grid">
                 <a href="<?php echo admin_url('admin.php?page=biaquiz-import-export'); ?>" class="biaquiz-action-card">
                     <div class="biaquiz-action-icon">📥</div>
-                    <h3>Importer un quiz</h3>
-                    <p>Téléversez vos quiz au format CSV ou JSON</p>
+                    <h3><?php echo esc_html__('Importer un quiz', 'acme-biaquiz'); ?></h3>
+                    <p><?php echo esc_html__('Téléversez vos quiz au format CSV ou JSON', 'acme-biaquiz'); ?></p>
                 </a>
                 
                 <a href="<?php echo admin_url('post-new.php?post_type=biaquiz'); ?>" class="biaquiz-action-card">
                     <div class="biaquiz-action-icon">➕</div>
-                    <h3>Créer un quiz</h3>
-                    <p>Créez un nouveau quiz manuellement</p>
+                    <h3><?php echo esc_html__('Créer un quiz', 'acme-biaquiz'); ?></h3>
+                    <p><?php echo esc_html__('Créez un nouveau quiz manuellement', 'acme-biaquiz'); ?></p>
                 </a>
                 
                 <a href="<?php echo admin_url('edit.php?post_type=biaquiz'); ?>" class="biaquiz-action-card">
                     <div class="biaquiz-action-icon">📋</div>
-                    <h3>Gérer les quiz</h3>
-                    <p>Voir et modifier tous les quiz existants</p>
+                    <h3><?php echo esc_html__('Gérer les quiz', 'acme-biaquiz'); ?></h3>
+                    <p><?php echo esc_html__('Voir et modifier tous les quiz existants', 'acme-biaquiz'); ?></p>
                 </a>
             </div>
         </div>
         
         <div class="biaquiz-shortcode-info">
-            <h2>Utilisation</h2>
-            <p>Pour afficher l'interface de quiz sur une page ou un article, utilisez le shortcode :</p>
+            <h2><?php echo esc_html__('Utilisation', 'acme-biaquiz'); ?></h2>
+            <p><?php echo esc_html__('Pour afficher l\'interface de quiz sur une page ou un article, utilisez le shortcode :', 'acme-biaquiz'); ?></p>
             <code>[biaquiz]</code>
             
-            <p>Vous pouvez également afficher une catégorie spécifique :</p>
+            <p><?php echo esc_html__('Vous pouvez également afficher une catégorie spécifique :', 'acme-biaquiz'); ?></p>
             <code>[biaquiz category="aerodynamics"]</code>
             
-            <p>Ou un quiz spécifique :</p>
+            <p><?php echo esc_html__('Ou un quiz spécifique :', 'acme-biaquiz'); ?></p>
             <code>[biaquiz quiz_id="123"]</code>
         </div>
     </div>

--- a/templates/admin-import-export.php
+++ b/templates/admin-import-export.php
@@ -5,18 +5,18 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
 ?>
 
 <div class="wrap">
-    <h1>Import / Export des Quiz</h1>
+    <h1><?php echo esc_html__('Import / Export des Quiz', 'acme-biaquiz'); ?></h1>
     
     <div class="biaquiz-import-export">
         <div class="biaquiz-section">
-            <h2>Importer un quiz</h2>
+            <h2><?php echo esc_html__('Importer un quiz', 'acme-biaquiz'); ?></h2>
             <div class="biaquiz-import-form">
                 <table class="form-table">
                     <tr>
-                        <th scope="row">Catégorie</th>
+                        <th scope="row"><?php echo esc_html__('Catégorie', 'acme-biaquiz'); ?></th>
                         <td>
                             <select id="import-category" required>
-                                <option value="">Sélectionner une catégorie</option>
+                                <option value=""><?php echo esc_html__('Sélectionner une catégorie', 'acme-biaquiz'); ?></option>
                                 <?php foreach ($categories as $category): ?>
                                 <option value="<?php echo esc_attr($category->slug); ?>">
                                     <?php echo esc_html($category->name); ?>
@@ -26,35 +26,35 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row">Format</th>
+                        <th scope="row"><?php echo esc_html__('Format', 'acme-biaquiz'); ?></th>
                         <td>
                             <label>
-                                <input type="radio" name="import-format" value="csv" checked> CSV
+                                <input type="radio" name="import-format" value="csv" checked> <?php echo esc_html__('CSV', 'acme-biaquiz'); ?>
                             </label>
                             <label>
-                                <input type="radio" name="import-format" value="json"> JSON
+                                <input type="radio" name="import-format" value="json"> <?php echo esc_html__('JSON', 'acme-biaquiz'); ?>
                             </label>
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row">Données</th>
+                        <th scope="row"><?php echo esc_html__('Données', 'acme-biaquiz'); ?></th>
                         <td>
-                            <textarea id="import-data" rows="10" cols="80" placeholder="Collez vos données ici..."></textarea>
+                            <textarea id="import-data" rows="10" cols="80" placeholder="<?php echo esc_attr__('Collez vos données ici...', 'acme-biaquiz'); ?>"></textarea>
                             <p class="description">
-                                Format CSV attendu : question,option1,option2,option3,option4,correct_answer,explanation<br>
-                                Le quiz doit contenir exactement 20 questions.
+                                <?php echo esc_html__('Format CSV attendu : question,option1,option2,option3,option4,correct_answer,explanation', 'acme-biaquiz'); ?><br>
+                                <?php echo esc_html__('Le quiz doit contenir exactement 20 questions.', 'acme-biaquiz'); ?>
                             </p>
                         </td>
                     </tr>
                 </table>
                 
                 <p class="submit">
-                    <button type="button" id="import-quiz" class="button button-primary">Importer le quiz</button>
+                    <button type="button" id="import-quiz" class="button button-primary"><?php echo esc_html__('Importer le quiz', 'acme-biaquiz'); ?></button>
                 </p>
             </div>
             
             <div class="biaquiz-csv-template">
-                <h3>Exemple de format CSV</h3>
+                <h3><?php echo esc_html__('Exemple de format CSV', 'acme-biaquiz'); ?></h3>
                 <pre>question,option1,option2,option3,option4,correct_answer,explanation
 "Quelle est la force qui s'oppose au mouvement d'un avion ?","La portance","La traînée","Le poids","La poussée",2,"La traînée est la force qui s'oppose au mouvement"
 "La portance est générée principalement par :","Le dessous de l'aile","Le dessus de l'aile","Les deux faces","L'hélice",2,"La portance est générée par la dépression au dessus de l'aile"</pre>
@@ -62,14 +62,14 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
         </div>
         
         <div class="biaquiz-section">
-            <h2>Exporter des quiz</h2>
+            <h2><?php echo esc_html__('Exporter des quiz', 'acme-biaquiz'); ?></h2>
             <div class="biaquiz-export-form">
                 <table class="form-table">
                     <tr>
-                        <th scope="row">Catégorie à exporter</th>
+                        <th scope="row"><?php echo esc_html__('Catégorie à exporter', 'acme-biaquiz'); ?></th>
                         <td>
                             <select id="export-category" required>
-                                <option value="">Sélectionner une catégorie</option>
+                                <option value=""><?php echo esc_html__('Sélectionner une catégorie', 'acme-biaquiz'); ?></option>
                                 <?php foreach ($categories as $category): ?>
                                 <option value="<?php echo esc_attr($category->slug); ?>">
                                     <?php echo esc_html($category->name); ?>
@@ -81,7 +81,7 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                 </table>
                 
                 <p class="submit">
-                    <button type="button" id="export-quiz" class="button button-secondary">Exporter en CSV</button>
+                    <button type="button" id="export-quiz" class="button button-secondary"><?php echo esc_html__('Exporter en CSV', 'acme-biaquiz'); ?></button>
                 </p>
             </div>
         </div>

--- a/templates/quiz-frontend.php
+++ b/templates/quiz-frontend.php
@@ -7,7 +7,7 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
 <div id="biaquiz-app" class="biaquiz-frontend">
     <div class="biaquiz-loading" id="biaquiz-loading">
         <div class="biaquiz-spinner"></div>
-        <p>Chargement...</p>
+        <p><?php echo esc_html__('Chargement...', 'acme-biaquiz'); ?></p>
     </div>
     
     <!-- Home View -->
@@ -16,34 +16,34 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
             <div class="biaquiz-logo">
                 <div class="biaquiz-logo-icon">✈️</div>
                 <div class="biaquiz-logo-text">
-                    <h1>ACME BIAQuiz</h1>
-                    <p>Entraînement au Brevet d'Initiation à l'Aéronautique</p>
+                    <h1><?php echo esc_html__('ACME BIAQuiz', 'acme-biaquiz'); ?></h1>
+                    <p><?php echo esc_html__('Entraînement au Brevet d\'Initiation à l\'Aéronautique', 'acme-biaquiz'); ?></p>
                 </div>
             </div>
         </div>
         
         <div class="biaquiz-intro">
-            <h2>Préparez votre BIA efficacement</h2>
-            <p>Entrainez-vous avec nos quiz thématiques interactifs. Aucune inscription requise, correction immédiate et répétition des erreurs jusqu'à la maîtrise parfaite.</p>
+            <h2><?php echo esc_html__('Préparez votre BIA efficacement', 'acme-biaquiz'); ?></h2>
+            <p><?php echo esc_html__('Entrainez-vous avec nos quiz thématiques interactifs. Aucune inscription requise, correction immédiate et répétition des erreurs jusqu\'à la maîtrise parfaite.', 'acme-biaquiz'); ?></p>
         </div>
         
         <div class="biaquiz-stats">
             <div class="biaquiz-stat">
                 <div class="biaquiz-stat-number"><?php echo count($categories); ?></div>
-                <div class="biaquiz-stat-label">Catégories disponibles</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Catégories disponibles', 'acme-biaquiz'); ?></div>
             </div>
             <div class="biaquiz-stat">
                 <div class="biaquiz-stat-number">60+</div>
-                <div class="biaquiz-stat-label">Questions d'entraînement</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Questions d\'entraînement', 'acme-biaquiz'); ?></div>
             </div>
             <div class="biaquiz-stat">
                 <div class="biaquiz-stat-number">100%</div>
-                <div class="biaquiz-stat-label">Score requis pour valider</div>
+                <div class="biaquiz-stat-label"><?php echo esc_html__('Score requis pour valider', 'acme-biaquiz'); ?></div>
             </div>
         </div>
         
         <div class="biaquiz-categories">
-            <h3>Choisissez votre domaine d'entraînement</h3>
+            <h3><?php echo esc_html__('Choisissez votre domaine d\'entraînement', 'acme-biaquiz'); ?></h3>
             <div class="biaquiz-categories-grid">
                 <?php foreach ($categories as $category): 
                     $args = array(
@@ -73,8 +73,8 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                     <div class="biaquiz-category-icon"><?php echo $icon; ?></div>
                     <h4><?php echo esc_html($category->name); ?></h4>
                     <p><?php echo esc_html($category->description); ?></p>
-                    <div class="biaquiz-category-count"><?php echo $count; ?> quiz disponible<?php echo $count > 1 ? 's' : ''; ?></div>
-                    <div class="biaquiz-category-action">Commencer l'entraînement →</div>
+                    <div class="biaquiz-category-count"><?php echo $count; ?> <?php echo esc_html__('quiz disponible', 'acme-biaquiz'); ?><?php echo $count > 1 ? esc_html__('s', 'acme-biaquiz') : ''; ?></div>
+                    <div class="biaquiz-category-action"><?php echo esc_html__('Commencer l\'entraînement →', 'acme-biaquiz'); ?></div>
                 </div>
                 <?php endforeach; ?>
             </div>
@@ -82,21 +82,21 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
         
         <div class="biaquiz-info">
             <div class="biaquiz-info-section">
-                <h4>Comment ça marche ?</h4>
+                <h4><?php echo esc_html__('Comment ça marche ?', 'acme-biaquiz'); ?></h4>
                 <ol>
-                    <li>Choisissez une catégorie selon vos besoins de révision</li>
-                    <li>Répondez aux 20 questions du quiz sélectionné</li>
-                    <li>Reprenez les questions ratées jusqu'à obtenir 20/20</li>
+                    <li><?php echo esc_html__('Choisissez une catégorie selon vos besoins de révision', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('Répondez aux 20 questions du quiz sélectionné', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('Reprenez les questions ratées jusqu\'à obtenir 20/20', 'acme-biaquiz'); ?></li>
                 </ol>
             </div>
             <div class="biaquiz-info-section">
-                <h4>Avantages</h4>
+                <h4><?php echo esc_html__('Avantages', 'acme-biaquiz'); ?></h4>
                 <ul>
-                    <li>✅ Accès immédiat sans inscription</li>
-                    <li>✅ Correction et explication instantanées</li>
-                    <li>✅ Répétition intelligente des erreurs</li>
-                    <li>✅ Interface responsive et intuitive</li>
-                    <li>✅ Contenu officiel conforme au BIA</li>
+                    <li><?php echo esc_html__('✅ Accès immédiat sans inscription', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('✅ Correction et explication instantanées', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('✅ Répétition intelligente des erreurs', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('✅ Interface responsive et intuitive', 'acme-biaquiz'); ?></li>
+                    <li><?php echo esc_html__('✅ Contenu officiel conforme au BIA', 'acme-biaquiz'); ?></li>
                 </ul>
             </div>
         </div>
@@ -105,7 +105,7 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
     <!-- Category View -->
     <div id="biaquiz-category" class="biaquiz-view">
         <div class="biaquiz-nav">
-            <button id="back-to-home" class="biaquiz-back-btn">← Retour aux catégories</button>
+            <button id="back-to-home" class="biaquiz-back-btn">← <?php echo esc_html__('Retour aux catégories', 'acme-biaquiz'); ?></button>
         </div>
         
         <div class="biaquiz-category-header">
@@ -122,7 +122,7 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
     <!-- Quiz View -->
     <div id="biaquiz-quiz" class="biaquiz-view">
         <div class="biaquiz-quiz-header">
-            <button id="back-to-category" class="biaquiz-back-btn">← Retour</button>
+            <button id="back-to-category" class="biaquiz-back-btn">← <?php echo esc_html__('Retour', 'acme-biaquiz'); ?></button>
             <h2 id="quiz-title"></h2>
             <div class="biaquiz-score">
                 <span id="current-score">0</span>/20
@@ -134,13 +134,13 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                 <div id="progress-fill" class="biaquiz-progress-fill"></div>
             </div>
             <div class="biaquiz-progress-text">
-                <span id="progress-text">Question 1/20</span>
-                <span id="progress-percentage">0% vers 20/20</span>
+                <span id="progress-text"><?php echo esc_html__('Question 1/20', 'acme-biaquiz'); ?></span>
+                <span id="progress-percentage">0% <?php echo esc_html__('vers 20/20', 'acme-biaquiz'); ?></span>
             </div>
         </div>
         
         <div id="review-mode-indicator" class="biaquiz-review-indicator" style="display: none;">
-            📚 Mode révision : Reprise des questions incorrectes
+            📚 <?php echo esc_html__('Mode révision : Reprise des questions incorrectes', 'acme-biaquiz'); ?>
         </div>
         
         <div class="biaquiz-question-container">
@@ -153,7 +153,7 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
             </div>
             
             <div id="question-explanation" class="biaquiz-explanation" style="display: none;">
-                <h4>Explication</h4>
+                <h4><?php echo esc_html__('Explication', 'acme-biaquiz'); ?></h4>
                 <p id="explanation-text"></p>
             </div>
             
@@ -162,8 +162,8 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                     <span id="wrong-questions-count" class="biaquiz-wrong-count" style="display: none;"></span>
                 </div>
                 <div class="biaquiz-question-buttons">
-                    <button id="validate-answer" class="biaquiz-btn biaquiz-btn-primary" disabled>Valider</button>
-                    <button id="next-question" class="biaquiz-btn biaquiz-btn-success" style="display: none;">Question suivante</button>
+                    <button id="validate-answer" class="biaquiz-btn biaquiz-btn-primary" disabled><?php echo esc_html__('Valider', 'acme-biaquiz'); ?></button>
+                    <button id="next-question" class="biaquiz-btn biaquiz-btn-success" style="display: none;"><?php echo esc_html__('Question suivante', 'acme-biaquiz'); ?></button>
                 </div>
             </div>
         </div>
@@ -173,17 +173,17 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
     <div id="biaquiz-completion" class="biaquiz-view">
         <div class="biaquiz-completion-content">
             <div class="biaquiz-trophy">🏆</div>
-            <h2>Félicitations !</h2>
-            <p>Vous avez terminé le quiz avec un score parfait</p>
+            <h2><?php echo esc_html__('Félicitations !', 'acme-biaquiz'); ?></h2>
+            <p><?php echo esc_html__('Vous avez terminé le quiz avec un score parfait', 'acme-biaquiz'); ?></p>
             
             <div class="biaquiz-final-score">
                 <div class="biaquiz-score-number">20/20</div>
-                <div class="biaquiz-score-label">Score parfait !</div>
+                <div class="biaquiz-score-label"><?php echo esc_html__('Score parfait !', 'acme-biaquiz'); ?></div>
             </div>
             
             <div class="biaquiz-completion-actions">
-                <button id="restart-quiz" class="biaquiz-btn biaquiz-btn-primary">🔄 Recommencer</button>
-                <button id="back-to-quizzes" class="biaquiz-btn biaquiz-btn-secondary">← Retour aux quiz</button>
+                <button id="restart-quiz" class="biaquiz-btn biaquiz-btn-primary">🔄 <?php echo esc_html__('Recommencer', 'acme-biaquiz'); ?></button>
+                <button id="back-to-quizzes" class="biaquiz-btn biaquiz-btn-secondary">← <?php echo esc_html__('Retour aux quiz', 'acme-biaquiz'); ?></button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add textdomain loading
- wrap strings in `acme-biaquiz.php` and templates with translation helpers
- generate an initial `languages/acme-biaquiz.pot` with `xgettext`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e572da8d8832b817b6af5889c62d4