### PR TITLE
Add file input for quiz import

### DIFF
--- a/assets/js/biaquiz-admin.js
+++ b/assets/js/biaquiz-admin.js
@@ -3,7 +3,7 @@
     'use strict';
     
     $(document).ready(function() {
-        
+
         // Import Quiz
         $('#import-quiz').on('click', function() {
             const category = $('#import-category').val();
@@ -44,6 +44,25 @@
                     $('#import-quiz').prop('disabled', false).text('Importer le quiz');
                 }
             });
+        });
+
+        // Import from file
+        $('#import-file').on('change', function(e) {
+            const file = this.files[0];
+            if (!file) return;
+
+            const reader = new FileReader();
+            reader.onload = function(ev) {
+                $('#import-data').val(ev.target.result);
+            };
+            reader.readAsText(file);
+
+            const ext = file.name.split('.').pop().toLowerCase();
+            if (ext === 'json') {
+                $('input[name="import-format"][value="json"]').prop('checked', true).trigger('change');
+            } else if (ext === 'csv') {
+                $('input[name="import-format"][value="csv"]').prop('checked', true).trigger('change');
+            }
         });
         
         // Export Quiz

--- a/templates/admin-import-export.php
+++ b/templates/admin-import-export.php
@@ -39,8 +39,10 @@ $categories = get_terms(array('taxonomy' => 'biaquiz_category', 'hide_empty' => 
                     <tr>
                         <th scope="row"><?php echo esc_html__('Données', 'acme-biaquiz'); ?></th>
                         <td>
+                            <input type="file" id="import-file" accept=".csv,.json">
                             <textarea id="import-data" rows="10" cols="80" placeholder="<?php echo esc_attr__('Collez vos données ici...', 'acme-biaquiz'); ?>"></textarea>
                             <p class="description">
+                                <?php echo esc_html__('Vous pouvez sélectionner un fichier CSV ou JSON, ou coller les données ci-dessous.', 'acme-biaquiz'); ?><br>
                                 <?php echo esc_html__('Format CSV attendu : question,option1,option2,option3,option4,correct_answer,explanation', 'acme-biaquiz'); ?><br>
                                 <?php echo esc_html__('Le quiz doit contenir exactement 20 questions.', 'acme-biaquiz'); ?>
                             </p>


### PR DESCRIPTION
## Summary
- allow uploading CSV/JSON in import form
- load selected file into textarea and auto-select the format

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e765e3388832b8cc17aa9ee3bfb1c